### PR TITLE
docs: fix python comment syntax and comment in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ pip install pyhuml
 ```python
 import pyhuml
 
-// Parse HUML into JS data structures.
+# Parse HUML into Python data structures.
 print(pyhuml.loads(huml_doc))
 
-// Dump JS data structures into HUML.
+# Dump Python data structures into HUML.
 print(pyhuml.dumps(obj))
 
 ```


### PR DESCRIPTION
Fix python usage code block.
1. Syntax for comment.
2. Fixed comment.