### PR TITLE
Fix: correctly report line number for ambiguous vector error

### DIFF
--- a/pyhuml/__init__.py
+++ b/pyhuml/__init__.py
@@ -501,13 +501,15 @@ def _parse_vector(p: Parser, indent: int) -> Union[List, Dict]:
     # Check for multiline vector
     if p.done() or p.data[p.pos] in '\n#':
         p.pos = start_pos
+        # Capture line number of the vector indicator before skipping ahead
+        vector_line = p.line
         p.consume_line()
 
         # Peek at next line to determine type
         p.skip_blank_lines()
 
         if p.done() or p.get_indent() < indent:
-            raise p.error("ambiguous empty vector after '::'. Use [] or {}.")
+            raise HUMLParseError("ambiguous empty vector after '::'. Use [] or {}.", vector_line)
 
         # Determine type by first character
         return (


### PR DESCRIPTION
Previously, the parser reported the error on the line *after* the vector indicator. This fix captures the line number before consuming the newline, ensuring the error message points to the correct location.