### PR TITLE
docs: fix usage snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,34 @@ pip install pyhuml
 ```python
 import pyhuml
 
+humlDoc = """\
+# A sample HUML document.
+website::
+  hostname: "huml.io"
+  ports:: 80, 443
+  enabled: true
+  factor: 3.14
+  props:: mime_type: "text/html", encoding: "gzip"
+  tags:: # Multi-line list.
+    - "markup"
+    - "webpage"
+    - "schema"
+
+haikus::
+  one: \"\"\"
+    A quiet language
+    Lines fall into their places
+    Nothing out of place
+  \"\"\"
+"""
+
 # Parse HUML into Python data structures.
-print(pyhuml.loads(huml_doc))
+obj = pyhuml.loads(humlDoc)
+print("Parsed Object:",obj)
 
 # Dump Python data structures into HUML.
-print(pyhuml.dumps(obj))
-
+huml_output = pyhuml.dumps(obj)
+print("Serialized Output:\n",huml_output)
 ```
 
 ### License


### PR DESCRIPTION
Current usage when simply copy pasted gives errors.
I have update the usage code snippet, added example humlDoc string and fixed other errors.